### PR TITLE
Make license more visible

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2016 falconed
+Copyright (c) 2016 Dan Falcone
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -35,3 +35,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/falconed/pgreset.
 
+## License
+
+The gem is available as open source under the terms of the [MIT
+License](https://opensource.org/licenses/MIT).

--- a/lib/pgreset.rb
+++ b/lib/pgreset.rb
@@ -5,7 +5,7 @@ module ActiveRecord
     class PostgreSQLDatabaseTasks
       def drop
         establish_master_connection
-        
+
         pid_column = 'pid'       # Postgresql 9.2 and newer
         if 0 == connection.select_all("SELECT column_name FROM information_schema.columns WHERE table_name = 'pg_stat_activity' AND column_name = 'pid';").count
           pid_column = 'procpid' # Postgresql 9.1 and older


### PR DESCRIPTION
Really minor thing here...

only making license in format as usually seen out here on github...

in some use cases this really makes a difference if you include gem in commercial projects and many times useful gems are not used due to licensing reasons or just that it was not visible enough :) 

Thanks