### PR TITLE
Fix rails >= 6.1.0 w/ ruby < 2.7

### DIFF
--- a/lib/pgreset.rb
+++ b/lib/pgreset.rb
@@ -6,10 +6,11 @@ module ActiveRecord
       def drop
         establish_master_connection
 
+        # `configuration_hash` was introduced in 6.1.0, prior versions have the database name in `configuration`.
         database_name =
-          begin
-            configuration_hash[:database] || configuration_hash.fetch('database')
-          rescue NoMethodError
+          if respond_to?(:configuration_hash, true)
+            configuration_hash.with_indifferent_access.fetch(:database)
+          else
             configuration['database']
           end
 

--- a/lib/pgreset.rb
+++ b/lib/pgreset.rb
@@ -8,7 +8,7 @@ module ActiveRecord
 
         database_name =
           begin
-            self.configuration_hash[:database] || self.configuration_hash.fetch('database')
+            configuration_hash[:database] || configuration_hash.fetch('database')
           rescue NoMethodError
             configuration['database']
           end


### PR DESCRIPTION
This is some addition to #5. To fix issue with ruby < 2.7, changing to use `respond_to?` instead of `rescue` for working with older rails version.

I've also applied @ekampp 's suggestion using `with_indifferent_access` (the method doesn't seem to have been deprecated https://api.rubyonrails.org/v4.2/classes/ActiveSupport/HashWithIndifferentAccess.html )